### PR TITLE
Slimdown size of image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,19 +13,20 @@ RUN dnf -y update && \
   yajl-devel \
   git \
   unzip \
-  ssdeep \ 
+  ssdeep \
   gcc \
-  wget
+  wget && \
+  dnf clean all
 
 # Download ModSecurity
 RUN mkdir -p /usr/share/ModSecurity && \
   cd /usr/share/ModSecurity && \
   wget --quiet "https://github.com/SpiderLabs/ModSecurity/releases/download/v2.9.1/modsecurity-2.9.1.tar.gz" && \
-  tar -xvzf modsecurity-2.9.1.tar.gz 
+  tar -xvzf modsecurity-2.9.1.tar.gz
 
 # Install ModSecurity
 RUN cd /usr/share/ModSecurity/modsecurity-2.9.1/ && \
-  sh autogen.sh && \ 
+  sh autogen.sh && \
   ./configure && \
   make && \
   make install

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN cd /usr/share/ModSecurity/modsecurity-2.9.1/ && \
   sh autogen.sh && \
   ./configure && \
   make && \
-  make install
+  make install && \
+  make clean
 
 # Move Files
 RUN cd /usr/share/ModSecurity/modsecurity-2.9.1/ && \


### PR DESCRIPTION
Note the SIZE columns below.
```
Before:
# docker images 
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
modsec              latest              5821e8dd49ea        3 minutes ago       821.6 MB
docker.io/fedora    25                  15895ef0b3b2        11 weeks ago        230.9 MB

After dnf clean:
# docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
modsec              latest              80249f84011a        10 seconds ago      653.3 MB
docker.io/fedora    25                  15895ef0b3b2        11 weeks ago        230.9 MB

After make clean:
# docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
modsec              latest              e3c593033360        4 minutes ago       634.6 MB
docker.io/fedora    25                  15895ef0b3b2        11 weeks ago        230.9 MB
```