### PR TITLE
replace httpd with apachectl and move unicode.mapping to correct dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN mkdir -p /etc/apache2/modsecurity.d/ && \
 
 RUN cd /etc/apache2/modsecurity.d/  && \
     mv /opt/ModSecurity/modsecurity.conf-recommended /etc/apache2/modsecurity.d/modsecurity.conf && \
+    mv /opt/ModSecurity/unicode.mapping /etc/apache2/modsecurity.d/unicode.mapping && \
     echo include modsecurity.conf >> /etc/apache2/modsecurity.d/include.conf && \
     git clone https://github.com/SpiderLabs/owasp-modsecurity-crs owasp-crs && \
     mv /etc/apache2/modsecurity.d/owasp-crs/crs-setup.conf.example /etc/apache2/modsecurity.d/owasp-crs/crs-setup.conf && \
@@ -57,4 +58,4 @@ RUN cd /etc/apache2/modsecurity.d/  && \
     
 EXPOSE 80
 
-CMD ["httpd", "-D", "FOREGROUND"]
+CMD ["apachectl", "-D", "FOREGROUND"]


### PR DESCRIPTION
Replace httpd with apachectl to avoid error:
```
[Thu Nov 08 15:53:18.376643 2018] [core:warn] [pid 1] AH00111: Config variable ${APACHE_RUN_DIR} is not defined
httpd: Syntax error on line 80 of /etc/apache2/apache2.conf: DefaultRuntimeDir must be a valid directory, absolute or relative to ServerRoot
```

Move missing unicode.mapping to correct directory. Missing unicode.mapping prevents Apache from starting:
```
AH00526: Syntax error on line 3 of /etc/apache2/mods-enabled/security.conf:
Rules error. File: /etc/apache2/modsecurity.d/modsecurity.conf. Line: 236. Column: 17. Failed to locate the unicode map file from: unicode.mapping Looking at: 'unicode.mapping', 'unicode.mapping', '/etc/apache2/modsecurity.d/unicode.mapping', '/etc/apache2/modsecurity.d/unicode.mapping'. 
```