### PR TITLE
Add  wget  unicode.mapping   to  fix  nginx  start error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,7 +134,9 @@ libyajl-dev \
 lua5.2-dev \
 libgeoip-dev \
 vim \
-libxml2
+libxml2 \
+wget
+
 RUN apt clean && \
 rm -rf /var/lib/apt/lists/*
 
@@ -158,7 +160,9 @@ RUN echo "include /etc/nginx/modsecurity.d/modsecurity.conf" > /etc/nginx/modsec
 COPY --from=modsecurity-build /opt/ModSecurity/modsecurity.conf-recommended /etc/nginx/modsecurity.d
 RUN cd /etc/nginx/modsecurity.d && \
     mv modsecurity.conf-recommended modsecurity.conf
-
+RUN cd /etc/nginx/modsecurity.d && \
+    wget https://raw.githubusercontent.com/SpiderLabs/ModSecurity/v3/master/unicode.mapping
+    
 EXPOSE 80
 
 STOPSIGNAL SIGTERM


### PR DESCRIPTION
Add  wget  unicode.mapping   to  fix  nginx  start error  
Error Detail in   container boot 
nginx: [emerg] "modsecurity_rules_file" directive Rules error. File: /etc/nginx/modsecurity.d/modsecurity.conf. Line: 236. Column: 17. Failed to locate the unicode map file from: unicode.mapping Looking at: 'unicode.mapping', 'unicode.mapping', '/etc/nginx/modsecurity.d/unicode.mapping', '/etc/nginx/modsecurity.d/unicode.mapping'.  in /etc/nginx/nginx.conf:39