### PR TITLE
Add extended access.log

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,8 @@ COPY --from=build /usr/local/lib/libfuzzy.so.2.1.0             		               
 COPY --from=build /usr/local/bin/ssdeep               		           	         /usr/local/bin/ssdeep
 COPY --from=build /usr/share/TLS/server.key                                              /usr/local/apache2/conf/server.key
 COPY --from=build /usr/share/TLS/server.crt                                              /usr/local/apache2/conf/server.crt
+COPY httpd-logging-before-modsec.conf                                                    /usr/local/apache2/conf/extra/httpd-logging-before-modsec.conf
+COPY httpd-logging-after-modsec.conf                                                     /usr/local/apache2/conf/extra/httpd-logging-after-modsec.conf
 
 RUN ln -s libfuzzy.so.2.1.0 /usr/local/lib/libfuzzy.so && \
 	ln -s libfuzzy.so.2.1.0 /usr/local/lib/libfuzzy.so.2 && \
@@ -73,11 +75,12 @@ RUN ln -s libfuzzy.so.2.1.0 /usr/local/lib/libfuzzy.so && \
 
 RUN sed -i -e 's/#LoadModule unique_id_module/LoadModule unique_id_module/g' /usr/local/apache2/conf/httpd.conf && \
 	sed -i -e 's/ServerTokens Full/ServerTokens Prod/g' /usr/local/apache2/conf/extra/httpd-default.conf && \
-  echo "ErrorLog /var/log/apache2/error.log"                                        >>	/usr/local/apache2/conf/httpd.conf && \
 	echo "LoadModule security2_module /usr/local/apache2/modules/mod_security2.so"    >>	/usr/local/apache2/conf/httpd.conf && \
 	echo "Include conf/extra/httpd-default.conf"   									                  >>	/usr/local/apache2/conf/httpd.conf && \
+	echo "Include conf/extra/httpd-logging-before-modsec.conf"							>>	/usr/local/apache2/conf/httpd.conf && \
 	echo "<IfModule security2_module>\nInclude /etc/modsecurity.d/include.conf\n</IfModule>" 	  >>	/usr/local/apache2/conf/httpd.conf && \
   echo "include \"/etc/modsecurity.d/modsecurity.conf\"" > /etc/modsecurity.d/include.conf && \
+	echo "Include conf/extra/httpd-logging-after-modsec.conf"  	                	  >>	/usr/local/apache2/conf/httpd.conf && \
   echo "ServerName $SERVERNAME" 												 	                        >> 	/usr/local/apache2/conf/httpd.conf && \
   echo "hello world" > /usr/local/apache2/htdocs/index.html
 

--- a/httpd-logging-before-modsec.conf
+++ b/httpd-logging-before-modsec.conf
@@ -8,9 +8,10 @@ ErrorLog		/var/log/apache2/error.log
 LoadModule logio_module /usr/local/apache2/modules/mod_logio.so
 
 LogFormat "%h %{GEOIP_COUNTRY_CODE}e %u [%{%Y-%m-%d %H:%M:%S}t.%{usec_frac}t] \"%r\" %>s %b \
-\"%{Referer}i\" \"%{User-Agent}i\" %v %A %p %R %{BALANCER_WORKER_ROUTE}e %X \"%{cookie}n\" \
-%{UNIQUE_ID}e %{SSL_PROTOCOL}x %{SSL_CIPHER}x %I %O %{ratio}n%% \
-%D %{ModSecTimeIn}e %{ApplicationTime}e %{ModSecTimeOut}e \
+\"%{Referer}i\" \"%{User-Agent}i\" \"%{Content-Type}i\" %{remote}p %v %A %p %R \
+%{BALANCER_WORKER_ROUTE}e %X \"%{cookie}n\" %{UNIQUE_ID}e %{SSL_PROTOCOL}x %{SSL_CIPHER}x \
+%I %O %{ratio}n%% %D %{ModSecTimeIn}e %{ApplicationTime}e %{ModSecTimeOut}e \
+%{ModSecAnomalyScoreInPLs}e %{ModSecAnomalyScoreOutPLs}e \
 %{ModSecAnomalyScoreIn}e %{ModSecAnomalyScoreOut}e" extended
 
 CustomLog		/var/log/apache2/access.log extended

--- a/httpd-logging-before-modsec.conf
+++ b/httpd-logging-before-modsec.conf
@@ -1,6 +1,7 @@
 ErrorLog		/var/log/apache2/error.log
 
-# For more information regarding the extended log format and the timestamp variables, please read:
+# For more information regarding the values in the extended log format
+# and aliases and scripts to extract information please read:
 # https://www.netnea.com/cms/apache-tutorial-5_extending-access-log/
 # https://www.netnea.com/cms/apache-tutorial-7_including-modsecurity-core-rules/
 # The timeout variables are empty for now and will be filled later when CRS is loaded into the CRS container.

--- a/httpd-logging-before-modsec.conf
+++ b/httpd-logging-before-modsec.conf
@@ -1,0 +1,16 @@
+ErrorLog		/var/log/apache2/error.log
+
+# For more information regarding the extended log format and the timestamp variables, please read:
+# https://www.netnea.com/cms/apache-tutorial-5_extending-access-log/
+# https://www.netnea.com/cms/apache-tutorial-7_including-modsecurity-core-rules/
+# The timeout variables are empty for now and will be filled later when CRS is loaded into the CRS container.
+
+LoadModule logio_module /usr/local/apache2/modules/mod_logio.so
+
+LogFormat "%h %{GEOIP_COUNTRY_CODE}e %u [%{%Y-%m-%d %H:%M:%S}t.%{usec_frac}t] \"%r\" %>s %b \
+\"%{Referer}i\" \"%{User-Agent}i\" %v %A %p %R %{BALANCER_WORKER_ROUTE}e %X \"%{cookie}n\" \
+%{UNIQUE_ID}e %{SSL_PROTOCOL}x %{SSL_CIPHER}x %I %O %{ratio}n%% \
+%D %{ModSecTimeIn}e %{ApplicationTime}e %{ModSecTimeOut}e \
+%{ModSecAnomalyScoreIn}e %{ModSecAnomalyScoreOut}e" extended
+
+CustomLog		/var/log/apache2/access.log extended


### PR DESCRIPTION
Add extended log format access.log.
I will also provide a PR for the Core Rule Set docker container.
There, the timeout variables will be filled.