### PR TITLE
Use nginx as base image instead of ubuntu

### DIFF
--- a/v2-nginx/Dockerfile
+++ b/v2-nginx/Dockerfile
@@ -1,5 +1,7 @@
-FROM ubuntu:18.04 as build 
+FROM nginx:1 as build
 MAINTAINER Chaim Sanders chaim.sanders@gmail.com
+
+ARG MODSEC_VERSION='2.9.3'
 
 # Install Prereqs
 RUN DEBIAN_FRONTEND=noninteractive \
@@ -17,38 +19,38 @@ RUN DEBIAN_FRONTEND=noninteractive \
       lua5.2-dev          \
       pkgconf             \
       ssdeep              \
+      zlib1g-dev          \
       wget             && \
     apt-get clean && rm -rf /var/lib/apt/lists/* 
 
 # Download ModSecurity
 RUN cd /opt && \
-    wget  --quiet https://github.com/SpiderLabs/ModSecurity/releases/download/v2.9.2/modsecurity-2.9.2.tar.gz && \
-    wget  --quiet https://nginx.org/download/nginx-1.13.9.tar.gz && \
-    tar -xzf modsecurity-2.9.2.tar.gz && \
-    tar -xzf nginx-1.13.9.tar.gz
+    wget  --quiet https://github.com/SpiderLabs/ModSecurity/releases/download/v$MODSEC_VERSION/modsecurity-$MODSEC_VERSION.tar.gz && \
+    tar -xzf modsecurity-$MODSEC_VERSION.tar.gz
 
 # Install ModSecurity
-RUN cd /opt/modsecurity-2.9.2/ && \
+RUN cd /opt/modsecurity-$MODSEC_VERSION/ && \
     sh autogen.sh && \
-    ./configure --enable-standalone-module && make
-
-RUN cd /opt/nginx-1.13.9 && \
-    ./configure --add-module=/opt/modsecurity-2.9.2/nginx/modsecurity --prefix=/usr/local/nginx --with-http_ssl_module && \
+    ./configure --enable-standalone-module && \
     make && make install && make clean
 
 # Move Files
-RUN cd /opt/modsecurity-2.9.2/ && \
-    mkdir -p /usr/local/nginx/conf/modsecurity.d && \
-    mv modsecurity.conf-recommended  /usr/local/nginx/conf/modsecurity.d/modsecurity.conf && \
-    mv unicode.mapping /usr/local/nginx/conf/modsecurity.d/ && \
-    printf "include modsecurity.conf" > /usr/local/nginx/conf/modsecurity.d/includes.conf && \
-    sed -i -e 's/^ *location \/.*/\tlocation \/ {\n\t    ModSecurityEnabled on;\n\t    ModSecurityConfig modsecurity.d\/includes.conf;/g' /usr/local/nginx/conf/nginx.conf
+RUN cd /opt/modsecurity-$MODSEC_VERSION/ && \
+    mkdir -p /etc/modsecurity.d && \
+    mv modsecurity.conf-recommended  /etc/modsecurity.d/modsecurity.conf && \
+    mv unicode.mapping /etc/modsecurity.d/ && \
+    printf "include modsecurity.conf" > /etc/modsecurity.d/includes.conf && \
+    sed -i '1iload_module modules/ngx_http_modsecurity_module.so;' /etc/nginx/nginx.conf && \
+    sed -i '1iload_module modules/ngx_http_modsecurity_module.so;' /etc/nginx/nginx.conf && \
+    sed -i -e 's/http {/http {\n    modsecurity on;\n    modsecurity_rules_file \/etc\/modsecurity.d\/include.conf;\n/g' /etc/nginx/nginx.conf
 
 ####################
 
-FROM ubuntu:18.04
+FROM nginx:1
 
-COPY --from=build /usr/local/nginx /usr/local/nginx
+COPY --from=build /etc/nginx/nginx.conf /etc/nginx/nginx.conf
+COPY --from=build /etc/modsecurity.d /etc/modsecurity.d
+COPY --from=build /usr/local/modsecurity/lib/standalone.so /etc/nginx/modules/ngx_http_modsecurity_module.so
 
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update -qq && \
@@ -66,4 +68,4 @@ EXPOSE 80
 
 STOPSIGNAL SIGTERM
 
-CMD ["/usr/local/nginx/sbin/nginx", "-g", "daemon off;"]
+CMD ["/usr/sbin/nginx", "-g", "daemon off;"]


### PR DESCRIPTION
As announced in https://github.com/CRS-support/modsecurity-docker/issues/32#issuecomment-558704419 we started to flatten selected branches into a directory structure on a new branch, called [master](https://github.com/CRS-support/modsecurity-docker/tree/master):

- `v2-apache/` <-- from [v2/apache-apache](https://github.com/CRS-support/modsecurity-docker/tree/v2/apache-apache)
- `v2-nginx/` <-- from [v2/ubuntu-nginx](https://github.com/CRS-support/modsecurity-docker/tree/v2/ubuntu-nginx)
- `v3-apache/` <-- from [v3/apache-apache](https://github.com/CRS-support/modsecurity-docker/tree/v3/apache-apache)
- `v3-nginx/` <-- from [v3/nginx-nginx](https://github.com/CRS-support/modsecurity-docker/tree/v3/nginx-nginx)

The [checkout-branches-to-folders.sh](https://github.com/CRS-support/modsecurity-docker/blob/master/checkout-branches-to-folders.sh#L19-L22) script documents where the structure comes from. (We will delete this script in future.)

## Current State

3 of the 4 directories have unchanged content. For the ModSecurity v2 + Nginx combination, however, we don't have a branch we could have simply taken over. Hence, we used the [v2/ubuntu-nginx](https://github.com/CRS-support/modsecurity-docker/tree/v2/ubuntu-nginx) branch instead, with the plan to refactor the image to base it on the [nginx](https://hub.docker.com/_/nginx) Docker image, as suggested by @csanders-git.

## undefined symbol: curl_easy_setopt

We tried to build the ModSecurity standalone and integrate it into Nginx, taking the approach from [v3/nginx-nginx](https://github.com/CRS-support/modsecurity-docker/tree/v3/nginx-nginx) as a role model.

Building the image works fine, but when we run Nginx the included ModSecurity binary complains about unresolved symbols:

```console
$ docker run --rm modsec:v2-nginx
2019/12/10 18:17:43 [emerg] 1#1: dlopen() "/etc/nginx/modules/ngx_http_modsecurity_module.so" failed (/etc/nginx/modules/ngx_http_modsecurity_module.so: undefined symbol: curl_easy_setopt) in /etc/nginx/nginx.conf:1
nginx: [emerg] dlopen() "/etc/nginx/modules/ngx_http_modsecurity_module.so" failed (/etc/nginx/modules/ngx_http_modsecurity_module.so: undefined symbol: curl_easy_setopt) in /etc/nginx/nginx.conf:1
```

Can you help us with that? Are there some linker options we need to add to configure?