### PR TITLE
Rename include.conf -> setup.conf

### DIFF
--- a/v2-apache/Dockerfile
+++ b/v2-apache/Dockerfile
@@ -83,8 +83,8 @@ RUN sed -i -E 's|(ServerTokens) Full|\1 Prod|' /usr/local/apache2/conf/extra/htt
  && sed -i -E 's|#(LoadModule unique_id_module)|\1|' /usr/local/apache2/conf/httpd.conf \
  && echo 'Include conf/extra/httpd-modsecurity.conf' >> /usr/local/apache2/conf/httpd.conf \
  && echo 'LoadModule security2_module /usr/local/apache2/modules/mod_security2.so' > /usr/local/apache2/conf/extra/httpd-modsecurity.conf \
- && echo 'Include /etc/modsecurity.d/include.conf' >> /usr/local/apache2/conf/extra/httpd-modsecurity.conf \
- && echo 'Include /etc/modsecurity.d/modsecurity.conf' > /etc/modsecurity.d/include.conf
+ && echo 'Include /etc/modsecurity.d/setup.conf' >> /usr/local/apache2/conf/extra/httpd-modsecurity.conf \
+ && echo 'Include /etc/modsecurity.d/modsecurity.conf' > /etc/modsecurity.d/setup.conf
 
 RUN if [ "$SETTLS" = "True" ]; then \
       echo "setting TLS"; \

--- a/v3-nginx/Dockerfile
+++ b/v3-nginx/Dockerfile
@@ -94,13 +94,13 @@ RUN export version=$(echo `/usr/sbin/nginx -v 2>&1` | cut -d '/' -f 2) && \
 
 RUN mkdir /etc/modsecurity.d && \
     cd /etc/modsecurity.d && \
-    echo "include \"/etc/modsecurity.d/modsecurity.conf\"" > include.conf && \
+    echo "include \"/etc/modsecurity.d/modsecurity.conf\"" > setup.conf && \
     wget --quiet https://raw.githubusercontent.com/SpiderLabs/ModSecurity/v3/master/modsecurity.conf-recommended && \
     mv modsecurity.conf-recommended modsecurity.conf && \
     wget --quiet https://raw.githubusercontent.com/SpiderLabs/ModSecurity/v3/master/unicode.mapping
 
 RUN sed -i '1iload_module modules/ngx_http_modsecurity_module.so;' /etc/nginx/nginx.conf && \
-    sed -i -e 's/http {/http {\n    modsecurity on;\n    modsecurity_rules_file \/etc\/modsecurity.d\/include.conf;\n/g' /etc/nginx/nginx.conf
+    sed -i -e 's/http {/http {\n    modsecurity on;\n    modsecurity_rules_file \/etc\/modsecurity.d\/setup.conf;\n/g' /etc/nginx/nginx.conf
 
 ENV LD_LIBRARY_PATH /lib:/usr/lib:/usr/local/lib
 


### PR DESCRIPTION
Renaming a file seems irrelevant and unneeded. These changes, though, correct the mental model the word "include" is meant to convey:

* In the context of the web proxy, Apache and Nginx, we mean to include configuration files from ModSecurity.
* In the context of ModSecurity that file is meant as the entrance point to set up the ModSecurity engine when included by the web proxy.

**Related changes:** https://github.com/CRS-support/modsecurity-crs-docker/pull/7 (downsteam image)