### PR TITLE
feat(http2): adds mod_http2 support for apache

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ $ docker run -p 8080:80 -e SERVER_NAME=myhost my-modsec
 * BACKEND - A string indicating the partial URL for the remote server of the `ProxyPass` directive (Default: `http://localhost:80`)
 * BACKEND_WS - A string indicating the IP/URL of the WebSocket service (Default: `ws://localhost:8080`)
 * ERRORLOG - A string value indicating the location of the error log file (Default: `/var/log/apache2/error.log`)
+* H2_PROTOCOLS - A string value indicating the protocols supported by the HTTP2 module (Default: `h2 http/1.1`)
 * LOGLEVEL - A string value controlling the number of messages logged to the error_log (Default: `warn`)
 * METRICS_ALLOW_FROM - A string indicating a range of IP adresses that can access the metrics (Default: `127.0.0.0/255.0.0.0 ::1/128`)
 * METRICS_DENY_FROM - A string indicating a range of IP adresses that cannot access the metrics (Default: `All`)

--- a/v2-apache/Dockerfile
+++ b/v2-apache/Dockerfile
@@ -49,6 +49,7 @@ ENV ACCESSLOG=/var/log/apache2/access.log \
     BACKEND=http://localhost:80 \
     BACKEND_WS=ws://localhost:8080 \
     ERRORLOG=/var/log/apache2/error.log \
+    H2_PROTOCOLS='h2 http/1.1' \
     LOGLEVEL=warn \
     METRICS_ALLOW_FROM='127.0.0.0/255.0.0.0 ::1/128' \
     METRICS_DENY_FROM='All' \
@@ -126,6 +127,7 @@ RUN sed -i -E 's|(Listen) [0-9]+|\1 ${PORT}|' /usr/local/apache2/conf/httpd.conf
  && sed -i -E 's|#(LoadModule remoteip_module modules/mod_remoteip.so)|\1|' /usr/local/apache2/conf/httpd.conf \
  && sed -i -E 's|#(LoadModule socache_shmcb_module modules/mod_socache_shmcb.so)|\1|' /usr/local/apache2/conf/httpd.conf \
  && sed -i -E 's|#(LoadModule ssl_module modules/mod_ssl.so)|\1|' /usr/local/apache2/conf/httpd.conf \
+ && sed -i -E 's|#(LoadModule http2_module modules/mod_http2.so)|\1|' /usr/local/apache2/conf/httpd.conf \
  && sed -i -E 's|#(Include conf/extra/httpd-default.conf)|\1|' /usr/local/apache2/conf/httpd.conf \
  && sed -i -E 's|#(Include conf/extra/httpd-proxy.conf)|\1|' /usr/local/apache2/conf/httpd.conf \
  && sed -i -E 's|#(Include conf/extra/httpd-ssl.conf)|\1|' /usr/local/apache2/conf/httpd.conf \

--- a/v2-apache/conf/extra/httpd-vhosts.conf
+++ b/v2-apache/conf/extra/httpd-vhosts.conf
@@ -30,6 +30,7 @@ SSLProxyCACertificateFile ${PROXY_SSL_CA_CERT}
 UseCanonicalName on
 
 <VirtualHost *:${SSL_PORT}>
+  Protocols ${H2_PROTOCOLS}
   SSLEngine ${SSL_ENGINE}
   SSLCertificateFile ${PROXY_SSL_CERT}
   SSLCertificateKeyFile ${PROXY_SSL_CERT_KEY}


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

This adds loading `mod_http2` in apache, and configuring default protocols.